### PR TITLE
fix: Renderização do botão após o preenchimento dos campos

### DIFF
--- a/src/components/DropdownPaymentMethods.tsx
+++ b/src/components/DropdownPaymentMethods.tsx
@@ -31,9 +31,13 @@ export const DropdownPaymentMethods = ({
   isLoading = false,
 }: DropdownPaymentMethodsProps) => {
   useEffect(() => {
-    onValueChange(options?.find((card) => card.default).id);
+    if (options && options.length > 0) {
+      const defaultCard = options.find((card) => card.default);
+      if (defaultCard) {
+        onValueChange(defaultCard.id);
+      }
+    }
   }, [options]);
-
   return (
     <Label name={label} className="max-w-[350px]">
       <Select.Root

--- a/src/components/layouts/MassCommunicationTemplate/index.tsx
+++ b/src/components/layouts/MassCommunicationTemplate/index.tsx
@@ -153,12 +153,11 @@ export const MassCommunicationTemplate = ({
   return (
     <>
       <LayoutWithSidebar hiddenInput={true}>
-        {isValid && (
+        {isValid && values.message && values.destinationVariable && (
           <Button
             type="button"
             className=" !h-[48px] !w-[200px] rounded-2xl text-xs font-medium fixed bottom-16 right-16"
             onClick={handleConfirm}
-            // disabled={!isValid}
           >
             Enviar <Check size={18} color="#FFF" />
           </Button>


### PR DESCRIPTION
Description:https://www.notion.so/d5ae41ba239644ab8f264bad8eb1fe11?v=316beaa28a5e499699f5d871f19cb645&p=bae33919f4cf44ad856aebb98b8ad9c1&pm=s

Tarefa concluida: Botão aparece apenas quando os demais campos estão selecionados:

![Sem preenchimento total](https://github.com/4codingg/callflow-frontend/assets/126209999/1e800115-4347-44cf-a0b0-bf3a0a420025)
![Preenchido](https://github.com/4codingg/callflow-frontend/assets/126209999/74844598-596b-4643-9978-f33edb6ce4a2)
